### PR TITLE
Remove Blueprint duplication in application

### DIFF
--- a/spendwise/api/v1/__init__.py
+++ b/spendwise/api/v1/__init__.py
@@ -1,3 +1,11 @@
 #!/usr/bin/env python3
 
 """For version 1 of the spendwise api"""
+
+from flask import Blueprint
+
+# define the blueprint to be used in all api files
+apis = Blueprint('apis', __name__)
+
+# make sure these modules are registered later
+from . import auth, budgets, categories, expenses

--- a/spendwise/api/v1/auth.py
+++ b/spendwise/api/v1/auth.py
@@ -13,12 +13,10 @@ from flask import (
 from werkzeug.security import generate_password_hash
 from ...models.user import User
 from ...models import storage
+from . import apis
 
 
-auth_bp = Blueprint('auth', __name__)
-
-
-@auth_bp.route('/register', methods=['POST'])
+@apis.route('/register', methods=['POST'])
 def signup():
     # collect form data
     data = request.get_json()
@@ -59,7 +57,7 @@ def signup():
     )
 
 
-@auth_bp.route('/login', methods=['POST'])
+@apis.route('/login', methods=['POST'])
 def login():
     """Logs the user into the application, if they already have an account"""
     # collect form data
@@ -88,7 +86,7 @@ def login():
     )
 
 
-@auth_bp.route('/logout')
+@apis.route('/logout')
 def logout():
     """Logs the user out of the application, redirecting them to the login page"""
     session.pop('current_user_id', None)  # end this users session

--- a/spendwise/api/v1/budgets.py
+++ b/spendwise/api/v1/budgets.py
@@ -5,8 +5,7 @@ from flask import Blueprint, jsonify, abort, request, make_response, session
 from ...models import storage
 from ...models.budget import Budget
 from .decorators import requires_logged_in_user
-
-apis = Blueprint('apis', __name__)
+from . import apis
 
 
 @apis.route('/budgets/add', methods=['POST'], strict_slashes=False)
@@ -58,9 +57,7 @@ def update_budget(Id):
     return make_response(jsonify(budget.to_dict()), 200)
 
 
-@apis.route(
-    '/budgets/delete/Id>', methods=['DELETE'], strict_slashes=False
-)
+@apis.route('/budgets/delete/Id>', methods=['DELETE'], strict_slashes=False)
 @requires_logged_in_user
 def delete_budget(Id):
     budget = storage.get(Budget, Id)

--- a/spendwise/api/v1/categories.py
+++ b/spendwise/api/v1/categories.py
@@ -4,8 +4,7 @@
 from flask import Blueprint, jsonify, abort, request, make_response
 from ...models import storage
 from ...models.category import Category
-
-apis = Blueprint('apis', __name__)
+from . import apis
 
 
 @apis.route('/categories', methods=['GET'], strict_slashes=False)
@@ -28,9 +27,7 @@ def add_category():
     return make_response(jsonify(new_category.to_dict()), 201)
 
 
-@apis.route(
-    '/categories/<categoryId>', methods=['PUT'], strict_slashes=False
-)
+@apis.route('/categories/<categoryId>', methods=['PUT'], strict_slashes=False)
 def update_category(categoryId):
     category = storage.get(Category, categoryId)
     if not category:

--- a/spendwise/api/v1/expenses.py
+++ b/spendwise/api/v1/expenses.py
@@ -4,8 +4,7 @@
 from flask import Blueprint, jsonify, abort, request, make_response
 from ...models import storage
 from ...models.expense import Expense
-
-apis = Blueprint('apis', __name__)
+from . import apis
 
 
 @apis.route('/expenses', methods=['GET'], strict_slashes=False)
@@ -37,9 +36,7 @@ def add_expense():
     return make_response(jsonify(expense.to_dict()), 201)
 
 
-@apis.route(
-    '/expenses/<expenseId>', methods=['PUT'], strict_slashes=False
-)
+@apis.route('/expenses/<expenseId>', methods=['PUT'], strict_slashes=False)
 def update_expense(expenseId):
     expense = storage.get(Expense, expenseId)
     if not expense:
@@ -54,9 +51,7 @@ def update_expense(expenseId):
     return make_response(jsonify(expense.to_dict()), 200)
 
 
-@apis.route(
-    '/expenses/<expenseId>', methods=['DELETE'], strict_slashes=False
-)
+@apis.route('/expenses/<expenseId>', methods=['DELETE'], strict_slashes=False)
 def delete_expense(expenseId):
     expense = storage.get(Expense, expenseId)
     if not expense:


### PR DESCRIPTION
- Blueprints that were defined in every file, have been removed and re-arranged so that each file only needs to import a blueprint defined once.
- The `app_views` blueprint has been renamed to `apis`
- The `auth_bp` blueprint has also been renamed to `apis`